### PR TITLE
Fix compile error for enum class type

### DIFF
--- a/include/pprint.hpp
+++ b/include/pprint.hpp
@@ -620,7 +620,7 @@ namespace pprint {
 		<< line_terminator;
       }
       else {
-	stream_ << std::string(indent, ' ') << value
+	stream_ << std::string(indent, ' ') << static_cast<std::underlying_type_t<T>>(value)
 		<< line_terminator;
       }
     }


### PR DESCRIPTION
I have compile error when try print 'enum class' type
```
include/pprint.hpp:623:38: error: no match for ‘operator<<’ (operand types are ‘std::basic_ostream<char>’ and ‘____C_A_T_C_H____T_E_S_T____36()::Color’)
  stream_ << std::string(indent, ' ') << value
```
Need cast to underlying type.  