### PR TITLE
Enable warnings as errors in tests and fix warning

### DIFF
--- a/include/pprint.hpp
+++ b/include/pprint.hpp
@@ -455,8 +455,8 @@ namespace pprint {
       stream_(stream),
       line_terminator_("\n"),
       indent_(2),
-      compact_(false),
-      quotes_(false) {}
+      quotes_(false),
+      compact_(false) {}
 
     PrettyPrinter& line_terminator(const std::string& value) {
       line_terminator_ = value;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -21,5 +21,11 @@ INCLUDE_DIRECTORIES("../include" ".")
 set_target_properties(PPRINT PROPERTIES OUTPUT_NAME tests)
 set_property(TARGET PPRINT PROPERTY CXX_STANDARD 17)
 
+if(MSVC)
+  target_compile_options(PPRINT PRIVATE /W4 /WX)
+else()
+  target_compile_options(PPRINT PRIVATE -Wall -Werror)
+endif()
+
 # Set ${PROJECT_NAME} as the startup project
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT PPRINT)


### PR DESCRIPTION
Great library, I have warnings as errors which I'd like to not exempt dependencies from. I think this helps improve the quality of this project. Thanks.