### PR TITLE
Fix incorrect setting of INTERFACE_INCLUDE_DIRECTORIES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ add_library(pprint::pprint ALIAS pprint)
 target_compile_features(pprint INTERFACE cxx_std_17)
 target_include_directories(pprint INTERFACE
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>/include)
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>)
 
 if(PPRINT_BUILD_TESTS)
   add_subdirectory(test)


### PR DESCRIPTION
Currently, the `INTERFACE_INCLUDE_DIRECTORIES` property in `pprintConfig.cmake` is set as:
```
set_target_properties(pprint::pprint PROPERTIES
  INTERFACE_COMPILE_FEATURES "cxx_std_17"
  INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include;/include"
)
```
and it causes building error for some users: https://github.com/microsoft/vcpkg/issues/7301 .