### PR TITLE
added inline so pprint can be included in multiple translation units …

### DIFF
--- a/include/pprint.hpp
+++ b/include/pprint.hpp
@@ -92,19 +92,19 @@ namespace pprint {
   struct gen_seq<0, Is...> : seq<Is...>{};
 
   template<typename T>
-  T to_string(T value) {
+  inline T to_string(T value) {
     return value;
   }
 
-  std::string to_string(char value) {
+  inline std::string to_string(char value) {
     return "'" + std::string(1, value) + "'";
   }
 
-  std::string to_string(const char * value) {
+  inline std::string to_string(const char * value) {
     return "\"" + std::string(value) + "\"";
   }  
     
-  std::string to_string(const std::string& value) {
+  inline std::string to_string(const std::string& value) {
     return "\"" + value + "\"";
   }
  


### PR DESCRIPTION
…of larger codebases

This allows various header files can include pprint and with no conflict of multiple redefinition. Maybe I missed more, but this fixes it for my needs at the moment.