### PR TITLE
conan: conan 'create .' will now build the recipe

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,8 +9,15 @@ class PprintConan(ConanFile):
     homepage = "https://github.com/p-ranav/pprint"
     url = "https://github.com/p-ranav/pprint"
     license = "MIT"
-    exports_sources = "include/pprint.hpp"
+    exports_sources = "include/**", "test/**", "CMakeLists.txt", "LICENSE"
+    exports = "LICENSE"
     no_copy_source = True
+
+    def set_version(self):
+        import re
+        m = re.search(r"project\(.*VERSION ([0-9.]+)", open(os.path.join(self.recipe_folder, "CMakeLists.txt")).read())
+        assert m, "Could not extract version from CMakeLists.txt"
+        self.version = m.group(1)
 
     _cmake = None
 
@@ -19,6 +26,7 @@ class PprintConan(ConanFile):
             return self._cmake
         self._cmake = CMake(self)
         self._cmake.configure()
+        return self._cmake
 
     def build(self):
         cmake = self._configure_cmake()


### PR DESCRIPTION
My previous pr broke conan in that it the version of the conanfile was not set properly.
Also, `conan build` did not work at all..
This is fixed in this pr.
It is now possible to create a conan package using:
```
conan create .
```